### PR TITLE
Rename event to ajax to prevent double response events

### DIFF
--- a/lancie-ajax.html
+++ b/lancie-ajax.html
@@ -125,7 +125,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       handleResponse: function(event) {
-        this.fire('response', event.detail);
+        this.fire('ajax', event.detail);
       },
 
       generateRequest: function() {


### PR DESCRIPTION
Sometimes the handler method is called twice, resulting in weird behavior. This changes the event name, omitting this problem.